### PR TITLE
Pop50 endpoint

### DIFF
--- a/lib/services/pop-service.ts
+++ b/lib/services/pop-service.ts
@@ -1,0 +1,86 @@
+import extractResponseData from "../utils/response-util";
+import TastytradeHttpClient from "./tastytrade-http-client";
+
+export interface Pop50Request {
+  "current-stock-price": number;
+  "current-time-at": Date;
+  "histogram-ideal-range-count": number;
+  "initial-cost": number;
+  "initial-cost-effect": string;
+  "interest-rate": number;
+  "target-fraction-of-cost": number;
+  volatility: number;
+  legs: PopRequestLeg[];
+  source: string;
+}
+
+export interface PopRequestLeg {
+  action: "sell_to_open" | "buy_to_open";
+  "asset-type": "Equity Option";
+  "call-or-put": "P" | "C";
+  "days-to-expiration": number;
+  quantity: number;
+  "strike-price": number;
+  "contract-implied-volatility": number;
+  "expiration-implied-volatility": number;
+}
+export interface Pop50Response {
+  "num-of-paths": number;
+  "steps-per-day": number;
+  "winner-count": number;
+  "total-milliseconds-to-compute": number;
+  "theoretical-cost": string;
+  "theoretical-cost-effect": "Debit" | "Credit";
+  "target-cost": string;
+  "target-cost-effect": string;
+  "conditional-value-at-risk-cost": string;
+  "conditional-value-at-risk-cost-effect": string;
+  "target-fraction-of-cost": string;
+  "probability-of-making-target": string;
+  "theoretical-price-movement-for-one-day": string;
+  "theoretical-spot-price": string;
+  "adjusted-implied-volatility-for-path": string;
+  "time-adjusted-implied-volatility-for-path": string;
+  "path-results": PathResult[];
+  "price-histogram": PopPriceHistogram[];
+  "winning-steps-histogram": PopWinningStepsHistogram[];
+}
+
+export interface PathResult {
+  cost: string;
+  "cost-effect": "Debit" | "Credit";
+  steps: number;
+  "stock-price": string;
+}
+
+export interface PopPriceHistogram {
+  low: string;
+  high: string;
+  count: number;
+  "range-index": number;
+}
+
+export interface PopWinningStepsHistogram {
+  low: string;
+  high: string;
+  count: number;
+  "range-index": number;
+}
+
+export default class PopService {
+  constructor(private httpClient: TastytradeHttpClient) {}
+
+  /**
+   * Get statistical estimation of 50% probability of profit
+   * @param requestData
+   * @returns {Pop50Response}
+   */
+  async get50Pop(requestData: Pop50Request): Promise<Pop50Response> {
+    const popResponse = await this.httpClient.postData(
+      "/fifty-percent-pop",
+      requestData,
+      {}
+    );
+    return extractResponseData(popResponse) as Pop50Response;
+  }
+}

--- a/lib/tastytrade-api.ts
+++ b/lib/tastytrade-api.ts
@@ -17,7 +17,7 @@ import SymbolSearchService from "./services/symbol-search-service"
 import TransactionsService from "./services/transactions-service"
 import WatchlistsService from "./services/watchlists-service"
 import TastytradeSession from "./models/tastytrade-session"
-
+import PopService from "./services/pop-service"
 export default class TastytradeClient {
   public readonly httpClient: TastytradeHttpClient
 
@@ -36,6 +36,7 @@ export default class TastytradeClient {
   public readonly symbolSearchService: SymbolSearchService
   public readonly transactionsService: TransactionsService
   public readonly watchlistsService: WatchlistsService
+  public readonly popService: PopService
 
   constructor(readonly baseUrl: string, readonly accountStreamerUrl: string) {
     this.httpClient = new TastytradeHttpClient(baseUrl)
@@ -54,6 +55,7 @@ export default class TastytradeClient {
     this.symbolSearchService = new SymbolSearchService(this.httpClient)
     this.transactionsService = new TransactionsService(this.httpClient)
     this.watchlistsService = new WatchlistsService(this.httpClient)
+    this.popService = new PopService(this.httpClient)
   }
 
   get session(): TastytradeSession {

--- a/tests/integration/service/pop-service.test.ts
+++ b/tests/integration/service/pop-service.test.ts
@@ -1,0 +1,44 @@
+import PopService, { Pop50Request } from "../../../lib/services/pop-service"
+import TastytradeHttpClient from "../../../lib/services/tastytrade-http-client";
+import SessionService from "../../../lib/services/session-service";
+import * as dotenv from 'dotenv'
+dotenv.config()
+
+const client = new TastytradeHttpClient(process.env.BASE_URL!)
+const popService = new PopService(client)
+
+beforeAll(async () => {
+  const sessionService = new SessionService(client)
+  await sessionService.login(process.env.API_USERNAME!, process.env.API_PASSWORD!)
+});
+
+const req: Pop50Request = {
+  "current-stock-price": 8.67,
+  "current-time-at": new Date(),
+  "histogram-ideal-range-count": 60,
+  "initial-cost": 43,
+  "initial-cost-effect": "Credit",
+  "interest-rate": 0.05,
+  "target-fraction-of-cost": 0.5,
+  "volatility": 0.575123919,
+  "legs": [
+      {
+          "action": "sell_to_open",
+          "asset-type": "Equity Option",
+          "call-or-put": "P",
+          "days-to-expiration": 54,
+          "quantity": 1,
+          "strike-price": 8,
+          "contract-implied-volatility": 0.558392479513946,
+          "expiration-implied-volatility": 0.635073669
+      }
+  ],
+  "source": "api-tests"
+}
+
+describe('get50Pop', () => {
+  it('response has expected property with a known value', async function() {
+    const response = await popService.get50Pop(req)
+    expect(response["num-of-paths"]).toEqual(1000)
+  })
+})


### PR DESCRIPTION
Hi,

I'd like to add a service for pop50 calculations. I put some interfaces to make it easier to work with the service, there may be missing properties since I had to guess them, this API is not documented yet. 

I've tested it with a basic integration test: `npm run test pop-service`
I've tried all tests and lots of them fail with https://api.cert.tastyworks.com, perhaps some parameters missing? Not sure. Let me know how to run whole test suite and I'l try. 

Thank you!
Roman