### PR TITLE
Engines enforcement

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -17,7 +17,7 @@ jobs:
           cache: 'npm'
       - run: npm install
       - run: npm run lint
-      - run: npm run test
+      - run: npm run unit-test
         env:
           BASE_URL: ${{ secrets.BASE_URL }}
           API_USERNAME: ${{ secrets.API_USERNAME }}

--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -6,7 +6,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x, 21.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/lib/services/tastytrade-http-client.ts
+++ b/lib/services/tastytrade-http-client.ts
@@ -3,6 +3,8 @@ import axios from "axios"
 import qs from 'qs'
 import { recursiveDasherizeKeys } from "../utils/json-util"
 import _ from 'lodash'
+import https from 'https'
+import { MinTlsVersion } from "../utils/constants"
 
 const ParamsSerializer = {
   serialize: function (queryParams: object) {
@@ -12,9 +14,11 @@ const ParamsSerializer = {
 
 export default class TastytradeHttpClient{
     public readonly session: TastytradeSession
+    private readonly httpsAgent: https.Agent
 
     constructor(private readonly baseUrl: string) {
       this.session = new TastytradeSession()
+      this.httpsAgent = new https.Agent({ minVersion: MinTlsVersion })
     }
 
     private getDefaultHeaders(): any {
@@ -37,7 +41,8 @@ export default class TastytradeHttpClient{
         data: dasherizedData,
         headers: mergedHeaders, 
         params: dasherizedParams,
-        paramsSerializer: ParamsSerializer
+        paramsSerializer: ParamsSerializer,
+        httpsAgent: this.httpsAgent
        }, _.isEmpty)
 
       return axios.request(config)

--- a/lib/utils/constants.ts
+++ b/lib/utils/constants.ts
@@ -1,0 +1,1 @@
+export const MinTlsVersion = 'TLSv1.2'

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,11 @@
         "ws": "^8.13.0"
       },
       "devDependencies": {
+        "@types/axios": "^0.14.0",
         "@types/jest": "^29.5.0",
-        "@types/node": "17.0.27",
+        "@types/node": "20.9.0",
         "@types/uuid": "^9.0.2",
+        "@types/ws": "^8.5.9",
         "@typescript-eslint/eslint-plugin": "^5.57.1",
         "@typescript-eslint/parser": "^5.57.1",
         "dotenv": "^16.0.3",
@@ -1220,6 +1222,16 @@
         "@sinonjs/commons": "^2.0.0"
       }
     },
+    "node_modules/@types/axios": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz",
+      "integrity": "sha512-KqQnQbdYE54D7oa/UmYVMZKq7CO4l8DEENzOKc4aBRwxCXSlJXGz83flFx5L7AWrOQnmuN3kVsRdt+GZPPjiVQ==",
+      "deprecated": "This is a stub types definition for axios (https://github.com/mzabriskie/axios). axios provides its own type definitions, so you don't need @types/axios installed!",
+      "dev": true,
+      "dependencies": {
+        "axios": "*"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.0",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.0.tgz",
@@ -1316,10 +1328,13 @@
       "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ=="
     },
     "node_modules/@types/node": {
-      "version": "17.0.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.27.tgz",
-      "integrity": "sha512-4/Ke7bbWOasuT3kceBZFGakP1dYN2XFd8v2l9bqF2LNWrmeU07JLpp56aEeG6+Q3olqO5TvXpW0yaiYnZJ5CXg==",
-      "dev": true
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
+      "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
@@ -1349,6 +1364,15 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
       "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==",
       "dev": true
+    },
+    "node_modules/@types/ws": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.9.tgz",
+      "integrity": "sha512-jbdrY0a8lxfdTp/+r7Z4CkycbOFN8WX+IOchLJr3juT/xzbJ8URyTVSJ/hvNdadTgM1mnedb47n+Y31GsFnQlg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.24",
@@ -4699,6 +4723,12 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
@@ -5831,6 +5861,15 @@
         "@sinonjs/commons": "^2.0.0"
       }
     },
+    "@types/axios": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz",
+      "integrity": "sha512-KqQnQbdYE54D7oa/UmYVMZKq7CO4l8DEENzOKc4aBRwxCXSlJXGz83flFx5L7AWrOQnmuN3kVsRdt+GZPPjiVQ==",
+      "dev": true,
+      "requires": {
+        "axios": "*"
+      }
+    },
     "@types/babel__core": {
       "version": "7.20.0",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.0.tgz",
@@ -5927,10 +5966,13 @@
       "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ=="
     },
     "@types/node": {
-      "version": "17.0.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.27.tgz",
-      "integrity": "sha512-4/Ke7bbWOasuT3kceBZFGakP1dYN2XFd8v2l9bqF2LNWrmeU07JLpp56aEeG6+Q3olqO5TvXpW0yaiYnZJ5CXg==",
-      "dev": true
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
+      "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/prettier": {
       "version": "2.7.2",
@@ -5960,6 +6002,15 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
       "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==",
       "dev": true
+    },
+    "@types/ws": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.9.tgz",
+      "integrity": "sha512-jbdrY0a8lxfdTp/+r7Z4CkycbOFN8WX+IOchLJr3juT/xzbJ8URyTVSJ/hvNdadTgM1mnedb47n+Y31GsFnQlg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/yargs": {
       "version": "17.0.24",
@@ -8365,6 +8416,12 @@
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
       "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "update-browserslist-db": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tastytrade/api",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tastytrade/api",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "^4.14.182",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tastytrade/api",
-  "version": "2.1.2",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tastytrade/api",
-      "version": "2.1.2",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "^4.14.182",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,10 @@
         "jest": "^29.5.0",
         "ts-jest": "^29.0.5",
         "typescript": "4.6.3"
+      },
+      "engines": {
+        "node": ">=20.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "repository": "https://github.com/tastytrade/tastytrade-api-js",
   "license": "MIT",
   "description": "Typescript impelementation of tastytrade api",
+  "engines" : { 
+    "npm" : ">=9.0.0",
+    "node" : ">=20.0.0"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "jest -i --restoreMocks",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "repository": "https://github.com/tastytrade/tastytrade-api-js",
   "license": "MIT",
   "description": "Typescript impelementation of tastytrade api",
-  "engines" : { 
-    "npm" : ">=9.0.0",
-    "node" : ">=20.0.0"
+  "engines": {
+    "npm": ">=9.0.0",
+    "node": ">=20.0.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
@@ -30,9 +30,11 @@
     "ws": "^8.13.0"
   },
   "devDependencies": {
+    "@types/axios": "^0.14.0",
     "@types/jest": "^29.5.0",
-    "@types/node": "17.0.27",
+    "@types/node": "20.9.0",
     "@types/uuid": "^9.0.2",
+    "@types/ws": "^8.5.9",
     "@typescript-eslint/eslint-plugin": "^5.57.1",
     "@typescript-eslint/parser": "^5.57.1",
     "dotenv": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tastytrade/api",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "main": "dist/tastytrade-api.js",
   "typings": "dist/tastytrade-api.d.ts",
   "repository": "https://github.com/tastytrade/tastytrade-api-js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tastytrade/api",
-  "version": "2.1.2",
+  "version": "3.0.0",
   "main": "dist/tastytrade-api.js",
   "typings": "dist/tastytrade-api.d.ts",
   "repository": "https://github.com/tastytrade/tastytrade-api-js",


### PR DESCRIPTION
We want to enforce a minimum node and npm version to ensure that users are running more up-to-date node libraries. Specifically, we want to ensure that the minimum tls version is defaulted to 1.2
See [here](https://nodejs.org/docs/v20.0.0/api/tls.html#tlsdefault_min_version) for more info.