### PR TITLE
Catch any errors when instantiating https.Agent

### DIFF
--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -37,7 +37,7 @@
     },
     "..": {
       "name": "@tastytrade/api",
-      "version": "2.1.1",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "^4.14.182",
@@ -51,8 +51,9 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.0",
-        "@types/node": "17.0.27",
+        "@types/node": "20.9.0",
         "@types/uuid": "^9.0.2",
+        "@types/ws": "^8.5.9",
         "@typescript-eslint/eslint-plugin": "^5.57.1",
         "@typescript-eslint/parser": "^5.57.1",
         "dotenv": "^16.0.3",
@@ -60,6 +61,10 @@
         "jest": "^29.5.0",
         "ts-jest": "^29.0.5",
         "typescript": "4.6.3"
+      },
+      "engines": {
+        "node": ">=20.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -11442,9 +11447,10 @@
       "requires": {
         "@types/jest": "^29.5.0",
         "@types/lodash": "^4.14.182",
-        "@types/node": "17.0.27",
+        "@types/node": "20.9.0",
         "@types/qs": "^6.9.7",
         "@types/uuid": "^9.0.2",
+        "@types/ws": "^8.5.9",
         "@typescript-eslint/eslint-plugin": "^5.57.1",
         "@typescript-eslint/parser": "^5.57.1",
         "axios": "^1.3.4",

--- a/lib/services/tastytrade-http-client.ts
+++ b/lib/services/tastytrade-http-client.ts
@@ -14,11 +14,16 @@ const ParamsSerializer = {
 
 export default class TastytradeHttpClient{
     public readonly session: TastytradeSession
-    private readonly httpsAgent: https.Agent
+    private readonly httpsAgent: https.Agent | null
 
     constructor(private readonly baseUrl: string) {
       this.session = new TastytradeSession()
-      this.httpsAgent = new https.Agent({ minVersion: MinTlsVersion })
+      try {
+        this.httpsAgent = new https.Agent({ minVersion: MinTlsVersion })
+      } catch (e) {
+        // Browsers should adhere to the min version, so allow the agent to be null
+        this.httpsAgent = null
+      }
     }
 
     private getDefaultHeaders(): any {

--- a/lib/services/tastytrade-http-client.ts
+++ b/lib/services/tastytrade-http-client.ts
@@ -3,8 +3,6 @@ import axios from "axios"
 import qs from 'qs'
 import { recursiveDasherizeKeys } from "../utils/json-util"
 import _ from 'lodash'
-import https from 'https'
-import { MinTlsVersion } from "../utils/constants"
 
 const ParamsSerializer = {
   serialize: function (queryParams: object) {
@@ -14,16 +12,9 @@ const ParamsSerializer = {
 
 export default class TastytradeHttpClient{
     public readonly session: TastytradeSession
-    private readonly httpsAgent: https.Agent | null
 
     constructor(private readonly baseUrl: string) {
       this.session = new TastytradeSession()
-      try {
-        this.httpsAgent = new https.Agent({ minVersion: MinTlsVersion })
-      } catch (e) {
-        // Browsers should adhere to the min version, so allow the agent to be null
-        this.httpsAgent = null
-      }
     }
 
     private getDefaultHeaders(): any {
@@ -53,8 +44,7 @@ export default class TastytradeHttpClient{
         data: dasherizedData,
         headers: mergedHeaders, 
         params: dasherizedParams,
-        paramsSerializer: ParamsSerializer,
-        httpsAgent: this.httpsAgent
+        paramsSerializer: ParamsSerializer
        }, _.isEmpty)
 
       return axios.request(config)


### PR DESCRIPTION
https://github.com/tastytrade/tastytrade-api-js/issues/18

Browsers should adhere to the 1.2 minimum TLS version, so we'll just catch any errors with this and move on.