### PR TITLE
chore: enable builds on latest-lts node version

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -6,7 +6,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 21.x]
+        node-version: [20.x, 21.x, 22.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
+          cache: "npm"
       - run: npm install
       - run: npm run lint
       - run: npm run unit-test


### PR DESCRIPTION
This PR enables builds on latest LTS node version