### PR TITLE
Fix symbol param in instruments/equity-options GET

### DIFF
--- a/lib/services/instruments-service.ts
+++ b/lib/services/instruments-service.ts
@@ -40,7 +40,7 @@ export default class InstrumentsService {
         }
 
         //Returns a set of equity options given one or more symbols
-        const queryParams = { symbols, active, withExpired }
+        const queryParams = { symbol: symbols, active, withExpired }
         const equityOptions = (await this.httpClient.getData(`/instruments/equity-options`, {}, queryParams))
         return extractResponseData(equityOptions)
     }


### PR DESCRIPTION
The param should be named `symbol` per the docs.