### PR TITLE
Fix OAuth token expiration.

### DIFF
--- a/lib/models/access-token.ts
+++ b/lib/models/access-token.ts
@@ -3,6 +3,7 @@ import _ from 'lodash'
 export default class AccessToken {
     public token = ''
     public expiresIn = 0
+    public createdAt: Date | null = null
 
     get isExpired(): boolean {
         return this.isEmpty || Date.now() >= this.expiration.getTime();
@@ -17,13 +18,15 @@ export default class AccessToken {
     }
 
     get expiration() {
+        if (!this.createdAt) return new Date()
         // Set expiration a bit earlier to account for clock skew
-        return new Date(Date.now() + ((this.expiresIn - 30) * 1000));
+        return new Date(this.createdAt.getTime() + ((this.expiresIn - 30) * 1000));
     }
 
     public updateFromTokenResponse(tokenResponse: any): void {
       this.token = _.get(tokenResponse, "data.access_token");
       this.expiresIn = _.get(tokenResponse, "data.expires_in");
+      this.createdAt = new Date()
     }
 
     get authorizationHeader(): string | null {
@@ -36,5 +39,6 @@ export default class AccessToken {
     clear() {
         this.token = ''
         this.expiresIn = 0
+        this.createdAt = null
     }
 }

--- a/lib/services/tastytrade-http-client.ts
+++ b/lib/services/tastytrade-http-client.ts
@@ -89,7 +89,8 @@ export default class TastytradeHttpClient {
         grant_type: 'refresh_token'
       }
 
-      const config = this.axiosConfig('post', '/oauth/token', params)
+      const headers = this.getDefaultHeaders()
+      const config = this.axiosConfig('post', '/oauth/token', params, headers)
       this.logger?.info('Making request', config)
       const tokenResponse = await axios.request(config)
       this.accessToken.updateFromTokenResponse(tokenResponse)

--- a/lib/services/tastytrade-http-client.ts
+++ b/lib/services/tastytrade-http-client.ts
@@ -89,8 +89,7 @@ export default class TastytradeHttpClient {
         grant_type: 'refresh_token'
       }
 
-      const headers = this.getDefaultHeaders()
-      const config = this.axiosConfig('post', '/oauth/token', params, headers)
+      const config = this.axiosConfig('post', '/oauth/token', params, this.getDefaultHeaders())
       this.logger?.info('Making request', config)
       const tokenResponse = await axios.request(config)
       this.accessToken.updateFromTokenResponse(tokenResponse)

--- a/tests/unit/service/tastytrade-http-client.test.ts
+++ b/tests/unit/service/tastytrade-http-client.test.ts
@@ -22,6 +22,7 @@ describe('needsTokenRefresh', () => {
     const client = createClient()
     client.accessToken.token = 'validtoken'
     client.accessToken.expiresIn = 3600
+    client.accessToken.createdAt = new Date()
     expect(client.needsTokenRefresh).toBe(false)
   })
 
@@ -29,6 +30,7 @@ describe('needsTokenRefresh', () => {
     const client = createClient()
     client.accessToken.token = 'validtoken'
     client.accessToken.expiresIn = 0
+    client.accessToken.createdAt = new Date()
     expect(client.needsTokenRefresh).toBe(true)
   })
 })

--- a/tests/unit/service/tastytrade-http-client.test.ts
+++ b/tests/unit/service/tastytrade-http-client.test.ts
@@ -20,17 +20,18 @@ function createClient() {
 describe('needsTokenRefresh', () => {
   it('returns false if accessToken is valid', function() {
     const client = createClient()
-    client.accessToken.token = 'validtoken'
-    client.accessToken.expiresIn = 3600
-    client.accessToken.createdAt = new Date()
+    client.accessToken.updateFromTokenResponse({ data: { access_token: 'validtoken', expires_in: 3600 } })
     expect(client.needsTokenRefresh).toBe(false)
   })
 
   it('returns true if accessToken is expired', function() {
     const client = createClient()
-    client.accessToken.token = 'validtoken'
-    client.accessToken.expiresIn = 0
-    client.accessToken.createdAt = new Date()
+    client.accessToken.updateFromTokenResponse({ data: { access_token: 'validtoken', expires_in: 0 } })
+    expect(client.needsTokenRefresh).toBe(true)
+  })
+
+  it('returns true if accessToken is empty', function() {
+    const client = createClient()
     expect(client.needsTokenRefresh).toBe(true)
   })
 })
@@ -38,9 +39,14 @@ describe('needsTokenRefresh', () => {
 describe('authHeader', () => {
   it('returns access token if AccessToken is valid', function() {
     const client = createClient()
-    client.accessToken.token = 'validtoken'
-    client.accessToken.expiresIn = 3600
+    client.accessToken.updateFromTokenResponse({ data: { access_token: 'validtoken', expires_in: 3600 } })
     expect(client.authHeader).toEqual('Bearer validtoken')
+  })
+
+  it('returns null if AccessToken is expired', function() {
+    const client = createClient()
+    client.accessToken.updateFromTokenResponse({ data: { access_token: 'validtoken', expires_in: 0 } })
+    expect(client.authHeader).toEqual(null)
   })
 
   it('returns null if access token is invalid', function() {
@@ -91,9 +97,7 @@ describe('updateConfig', () => {
     const client = createClient()
     const targetApiVersion = '20250925'
     client.updateConfig({ targetApiVersion })
-    client.accessToken.token = 'validtoken'
-    client.accessToken.expiresIn = 3600
-
+    client.accessToken.updateFromTokenResponse({ data: { access_token: 'validtoken', expires_in: 3600 } })
 
     expect(client.targetApiVersion).toEqual(targetApiVersion)
     console.log('client.accessToken.token: ', client.accessToken.token, ' client.accessToken.expiresIn: ', client.accessToken.expiresIn)


### PR DESCRIPTION
As detailed in https://github.com/tastytrade/tastytrade-api-js/issues/64#issuecomment-3918248463, the `expiration` getter on the access token class is improperly configured to return the current date plus the "expires in" time. This results in the returned expiration time always being in the future, causing the token to never be marked as expired and never renewing.

This PR adds a new `createdAt` field to the access token, which is set to the time the token was generated. This can be useful for determining when a token was last generated, in addition to being used for the correct calculation of the expiration time.
I also edited the unit test file to add this property, but there are typescript errors unrelated to this PR that cause the tests to fail.

This PR also adds the headers as detailed in https://github.com/tastytrade/tastytrade-api-js/issues/64#issue-3955085478.

closes #64 