### PR TITLE
fix bug causing subscribeToAccounts() promise to never complete

### DIFF
--- a/lib/account-streamer.ts
+++ b/lib/account-streamer.ts
@@ -228,8 +228,14 @@ export class AccountStreamer {
    * @returns
    */
   async send(json: JsonBuilder): Promise<number> {
+
+    // Grab the next requestId
+    // This is saved as a const to ensure there is no path which could result in
+    // this.requestCounter being changed under us if we yield awaiting a new token.
     this.requestCounter += 1
-    json.add(REQUEST_ID, this.requestCounter)
+    const requestId = this.requestCounter
+
+    json.add(REQUEST_ID, requestId)
     json.add('source', SOURCE)
 
     if (this.httpClient.needsTokenRefresh) {
@@ -248,7 +254,7 @@ export class AccountStreamer {
       websocket.send(message)
     }
 
-    return this.requestCounter
+    return requestId
   }
 
   /**
@@ -388,10 +394,14 @@ export class AccountStreamer {
         this.scheduleHeartbeatTimer()
       }
 
-      const promiseCallbacks = this.requestPromises.get(
-        json[REQUEST_ID] as number
-      )
+      // Unpack the request id from the response.
+      // This may be returned as a string, so we use Number() to ensure it is converted
+      const reqId = Number(json[REQUEST_ID]);
+
+      const promiseCallbacks = this.requestPromises.get(reqId);
       if (promiseCallbacks) {
+        this.requestPromises.delete(reqId);
+
         const [resolve, reject] = promiseCallbacks
         const status = json.status as string
         if (status === 'ok') {


### PR DESCRIPTION
Fixes [Issue 61](https://github.com/tastytrade/tastytrade-api-js/issues/61).

The problem is that while the outgoing `request-id` is a number, the incoming `request-id` from the backend in the response is a string (screenshot attached). 

The original code extracted the response value using `as number` which satisfies the typescript compiler, but leaves the value as a string, causing the entry in the map to not be found, and the promise to never complete. The change instead passes the value extracted to `Number()` which ensures it is parsed if it is a string, and then matches the entry in the map.

<img width="1175" height="55" alt="Screenshot 2026-05-11 at 17 52 06" src="https://github.com/user-attachments/assets/fc2f81a4-2ad5-4382-95a1-09b401d1999e" />
